### PR TITLE
Document development setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS
+
+This repository is a Python SDK for interacting with Zyxel NR5103E routers.
+
+## Workflow
+- Use the Python version specified in `.python-version`.
+- Source files live under `src/` and tests under `tests/`.
+- Run `bin/format` to apply ruff autoformatting.
+- Run `bin/test` after changes. It performs ruff linting, checks formatting, runs mypy and pytest.
+
+Always run both commands before committing code.
+
+## Development Setup
+The project configuration and dependencies live in `pyproject.toml`.
+Create a virtual environment and install the SDK in editable mode with its
+`dev` extras to get the tooling used by `bin/format` and `bin/test`:
+
+```sh
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```


### PR DESCRIPTION
## Summary
- expand AGENTS instructions with a section on installing dev dependencies
- remove hardcoded Python version reference

## Testing
- `bin/format`
- `PYTHONPATH=src bin/test`


------
https://chatgpt.com/codex/tasks/task_b_68739f8609dc8325ab1730546e6895a3