### PR TITLE
Fix GHA job dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,7 @@ jobs:
           path: dist/
 
   publish:
+    needs: build
     runs-on: ubuntu-latest
     environment:
       name: pypi


### PR DESCRIPTION
This pull request updates the workflow configuration for releases by adding a dependency to the `publish` job, ensuring it waits for the `build` job to complete before running.

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR25): Added `needs: build` to the `publish` job to establish a dependency on the `build` job, ensuring proper execution order in the release workflow.