### PR TITLE
Fix Python dist dir

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ jobs:
           python -m build
       - uses: actions/upload-artifact@v4
         with:
+          name: python-dist
           path: dist/
 
   publish:
@@ -31,4 +32,7 @@ jobs:
       id-token: write
     steps:
       - uses: actions/download-artifact@v4
+        with:
+          name: python-dist
+          path: dist/
       - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` file to improve artifact handling in the release workflow. The changes ensure that the Python distribution artifact is named explicitly and downloaded correctly for publishing.

### Workflow improvements:

* Added an explicit artifact name, `python-dist`, when uploading the Python distribution in the `build` job. (`.github/workflows/release.yaml`, [.github/workflows/release.yamlR22](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR22))
* Updated the `publish` job to download the artifact by its explicit name, `python-dist`, ensuring proper handling of the distribution files. (`.github/workflows/release.yaml`, [.github/workflows/release.yamlR35-R37](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR35-R37))